### PR TITLE
Implement Edge Security Headers (CSP & HSTS)

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.7",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
+      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    },
+    "ghcr.io/devcontainers/features/desktop-lite:1": {
+      "version": "1.2.9",
+      "resolved": "ghcr.io/devcontainers/features/desktop-lite@sha256:d8649bc8ca8e50a52fbee29d281739ea05dc1022905b185434d6bbe9afc8f221",
+      "integrity": "sha256:d8649bc8ca8e50a52fbee29d281739ea05dc1022905b185434d6bbe9afc8f221"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.9.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850",
+      "integrity": "sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850"
+    }
+  }
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -4,5 +4,24 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dso25ht-backend.ampyourlight.com/; img-src 'self' data:;"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        }
+      ]
+    }
   ]
 }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -11,7 +11,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dso25ht-backend.ampyourlight.com/; img-src 'self' data:;"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dso25ht-backend.ampyourlight.com; img-src 'self' data:;"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
This PR remediates ZAP scanner vulnerabilities regarding missing security headers. By implementing a vercel.json configuration, we now leverage Vercel's Edge network to inject strict HTTP security headers into every response before it reaches the client, drastically reducing our Cross-Site Scripting (XSS) attack surface.

## Key Changes

- Content Security Policy (CSP): Implemented a strict allowlist. The connect-src directive has been explicitly locked down to only allow communication with our Railway FastAPI backend.
- Hardening Headers: Added X-Content-Type-Options: nosniff and Strict-Transport-Security (HSTS) to force secure connections.
- SPA Routing Preserved: Safely merged the new headers with our existing rewrites block to ensure React client-side routing continues functioning perfectly.