### PR TITLE
Mitigate Clickjacking Vulnerability (Edge Security Headers)

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -11,7 +11,11 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dso25ht-backend.ampyourlight.com; img-src 'self' data:;"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://dso25ht-backend.ampyourlight.com; img-src 'self' data:; frame-ancestors 'none';"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
This PR remediates a ZAP scanner finding for missing anti-clickjacking headers. By explicitly denying the ability to embed our React application within an <iframe>, we protect our users from UI redressing (clickjacking) attacks.

## Key Changes

- Modern CSP Directive: Added frame-ancestors 'none'; to our existing Content Security Policy in vercel.json.
- Legacy Browser Support: Added the X-Frame-Options: DENY header to ensure complete coverage across older browser engines.

## Security Impact

The application can no longer be maliciously framed by third-party attacker domains, effectively neutralizing clickjacking attack vectors at the Vercel Edge layer.